### PR TITLE
fix for "ReferenceError: store is not defined" in pushMessage

### DIFF
--- a/ember-data-sails-adapter.js
+++ b/ember-data-sails-adapter.js
@@ -174,7 +174,7 @@ DS.SailsSocketAdapter = DS.SailsAdapter = DS.Adapter.extend(SailsAdapterMixin, {
 
   _listenToSocket: function() {
     var self = this;
-    //var store = this.container.lookup('store:main');
+    var store = this.container.lookup('store:main');
 
     function findModelName(model) {
       var mappedName = self.modelNameMap[model];


### PR DESCRIPTION
1.x branch is broken for push. The error is "ReferenceError: store is not defined". It seems that the fix is simple.
