### PR TITLE
Fixes an issue where data was double-wrapped when using SocketAdapter

### DIFF
--- a/ember-data-sails-adapter.js
+++ b/ember-data-sails-adapter.js
@@ -69,19 +69,19 @@ DS.SailsSocketAdapter = DS.SailsAdapter = DS.SailsRESTAdapter.extend({
   },
 
 
-  ajax: function(url, method, data) {
-    return this.socket(url, method, data);
+  ajax: function(url, method, options) {
+    return this.socket(url, method, options);
   },
 
-  socket: function(url, method, data) {
+  socket: function(url, method, options) {
     var isErrorObject = this.isErrorObject.bind(this);
     method = method.toLowerCase();
     var adapter = this;
-    adapter._log(method, url, data);
+    adapter._log(method, url, options.data);
     if(method !== 'get')
-      this.checkCSRF(data);
+      this.checkCSRF(options.data);
     return new RSVP.Promise(function(resolve, reject) {
-      io.socket[method](url, data, function (data) {
+      io.socket[method](url, options.data, function (data) {
         if (isErrorObject(data)) {
           adapter._log('error:', data);
           if (data.errors) {


### PR DESCRIPTION
Resolves: https://github.com/bmac/ember-data-sails-adapter/issues/35

I wasn't able to get the qunit tests running because of duelling versions in bower (jQuery 2.1.1 vs Ember 1.7 vs Ember-Data 1.0.0-beta12).

I tested it in a live sails instance running Ember 1.9.0-beta.1 and it seemed to. worked great.
